### PR TITLE
Add SKU field to items and update UI

### DIFF
--- a/main.py
+++ b/main.py
@@ -206,12 +206,18 @@ def delete_supplier(sup_id: int, db: Session = Depends(get_db), user: User = Dep
 # ---------------------- Items ----------------------
 @app.get("/items", response_class=HTMLResponse)
 def list_items(request: Request, db: Session = Depends(get_db), user: User = Depends(require_user)):
-    items = db.query(Item).order_by(Item.name).all()
+    items = db.query(Item).order_by(Item.sku, Item.name).all()
     return templates.TemplateResponse("items.html", {"request": request, "items": items})
 
 @app.post("/items")
-def create_item(name: str = Form(...), unit: str = Form(""), db: Session = Depends(get_db), user: User = Depends(require_user)):
-    i = Item(name=name.strip(), unit=unit.strip())
+def create_item(
+    name: str = Form(...),
+    sku: str = Form(...),
+    unit: str = Form(""),
+    db: Session = Depends(get_db),
+    user: User = Depends(require_user),
+):
+    i = Item(name=name.strip(), sku=sku.strip(), unit=unit.strip())
     db.add(i)
     db.commit()
     return RedirectResponse("/items", status_code=303)

--- a/models.py
+++ b/models.py
@@ -73,6 +73,7 @@ class Item(Base):
     __tablename__ = "items"
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, nullable=False, unique=True)
+    sku = Column(String, nullable=False, unique=True, index=True)
     unit = Column(String, nullable=True)   # e.g., pcs, kg, box
 
 # ----------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ jinja2==3.1.4
 python-multipart==0.0.9
 psycopg2-binary==2.9.9
 passlib[bcrypt]==1.7.4
+bcrypt==4.0.1
 itsdangerous==2.2.0

--- a/templates/entries.html
+++ b/templates/entries.html
@@ -42,7 +42,7 @@
       <select name="party_ids" class="border rounded-lg p-2 party-select item-select hidden">
         <option value="">-- Select Item --</option>
         {% for i in items %}
-        <option value="{{ i.id }}">{{ i.name }}</option>
+        <option value="{{ i.id }}">{{ i.sku }} - {{ i.name }}</option>
         {% endfor %}
       </select>
 
@@ -101,7 +101,7 @@ function addLine(){
 
     <select name="party_ids" class="border rounded-lg p-2 party-select item-select hidden">
       <option value="">-- Select Item --</option>
-      {% for i in items %}<option value="{{ i.id }}">{{ i.name }}</option>{% endfor %}
+      {% for i in items %}<option value="{{ i.id }}">{{ i.sku }} - {{ i.name }}</option>{% endfor %}
     </select>
 
     <input name="qtys" type="number" step="0.01" placeholder="Qty" class="border rounded-lg p-2">

--- a/templates/items.html
+++ b/templates/items.html
@@ -3,18 +3,20 @@
 <h1 class="text-2xl font-bold mb-4">Items</h1>
 
 <form method="post" class="bg-white rounded-2xl shadow p-4 mb-6 grid grid-cols-1 md:grid-cols-2 gap-3">
+  <input name="sku" required placeholder="SKU" class="border rounded-lg p-2">
   <input name="name" required placeholder="Item Name" class="border rounded-lg p-2">
-  <input name="unit" placeholder="Unit (pcs, kg, etc)" class="border rounded-lg p-2">
-  <button class="bg-black text-white px-4 py-2 rounded-lg w-max">Add</button>
+  <input name="unit" placeholder="Unit (pcs, kg, etc)" class="border rounded-lg p-2 md:col-span-2">
+  <button class="bg-black text-white px-4 py-2 rounded-lg w-max md:col-span-2">Add</button>
 </form>
 
 <table class="w-full bg-white rounded-2xl shadow overflow-hidden">
   <thead class="bg-gray-100 text-left">
-    <tr><th class="p-3">Name</th><th class="p-3">Unit</th><th class="p-3">Actions</th></tr>
+    <tr><th class="p-3">SKU</th><th class="p-3">Name</th><th class="p-3">Unit</th><th class="p-3">Actions</th></tr>
   </thead>
   <tbody>
     {% for i in items %}
     <tr class="border-t">
+      <td class="p-3 font-mono">{{ i.sku }}</td>
       <td class="p-3">{{ i.name }}</td>
       <td class="p-3">{{ i.unit }}</td>
       <td class="p-3">


### PR DESCRIPTION
## Summary
- add a dedicated, unique SKU field to the Item model and creation flow
- display and capture SKUs on the inventory management page and entry item selectors
- pin bcrypt to a compatible version to ensure the app can start up with passlib

## Testing
- uvicorn main:app --host 0.0.0.0 --port 8000

------
https://chatgpt.com/codex/tasks/task_e_68e4490a86cc83258da8a1b4fe904521