### PR TITLE
Route root to login and expose dashboard at /dashboard

### DIFF
--- a/main.py
+++ b/main.py
@@ -122,7 +122,7 @@ def login_post(
     request: Request,
     username: str = Form(...),
     password: str = Form(...),
-    next: str = Form("/"),
+    next: str = Form("/dashboard"),
     db: Session = Depends(get_db),
 ):
     user = db.query(User).filter(User.username == username).first()
@@ -141,6 +141,12 @@ def logout(request: Request):
 
 # ---------------------- Protected Pages ----------------------
 @app.get("/", response_class=HTMLResponse)
+def root(request: Request):
+    if request.session.get("uid"):
+        return RedirectResponse("/dashboard", status_code=303)
+    return RedirectResponse("/login", status_code=303)
+
+@app.get("/dashboard", response_class=HTMLResponse)
 def dashboard(request: Request, db: Session = Depends(get_db), user: User = Depends(require_user)):
     today = date.today()
     start_month = today.replace(day=1)
@@ -538,4 +544,3 @@ def balance_sheet(request: Request, as_of: str | None = None, db: Session = Depe
         "assets_total": assets_total, "liab_total": liab_total,
         "equity_total": equity_total, "liab_equity_total": liab_equity_total
     })
-


### PR DESCRIPTION
### Motivation
- Make the application root (`/`) present the login page to unauthenticated visitors while preserving a direct path to the dashboard for authenticated users.
- Ensure successful logins default to the dashboard rather than the root path.

### Description
- Changed the default `next` form value in `login_post` from `/` to `/dashboard` so successful logins route to the dashboard by default.
- Replaced the previous protected `@app.get("/")` dashboard handler with a lightweight `root()` that redirects unauthenticated users to `/login` and authenticated users to `/dashboard`.
- Added an explicit protected `@app.get("/dashboard")` route that contains the existing dashboard rendering and business logic.
- Kept the existing `_is_safe_next` check so unsafe `next` values fall back to `/`.

### Testing
- Ran `python -m py_compile main.py` and the file compiled successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a069e3a7ff8832580d4bc1d547e1d8a)