### PR TITLE
Replace login page heading with PixiePinks logo

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -6,9 +6,13 @@
   
   <div class="bg-white shadow-2xl rounded-2xl p-10 w-full max-w-md">
 
-    <h1 class="text-4xl font-bold mb-8 text-center">
-      Sign in
-    </h1>
+    <div class="flex justify-center mb-8">
+      <img
+        src="/static/images/login_logo.png"
+        alt="PixiePinks Logo"
+        class="w-72 h-auto object-contain drop-shadow-lg"
+      >
+    </div>
 
     <form method="post" class="space-y-5">
 


### PR DESCRIPTION
### Motivation
- Replace the plain “Sign in” heading with the PixiePinks logo to give the login card a modern, premium, and clean brand presentation while preserving layout and behavior.

### Description
- Removed the existing `<h1>` title and added a centered logo block at the top of the login card using `<img src="/static/images/login_logo.png" alt="PixiePinks Logo" class="w-72 h-auto object-contain drop-shadow-lg">`, leaving the username field, password field, login button, and the centering container (`min-h-[80vh] flex items-center justify-center`) unchanged.

### Testing
- No automated tests were executed for this presentation-only template change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06ae0cc9a4832593a10fa550e0b865)