### PR TITLE
Reduce login logo size on login page

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -10,7 +10,7 @@
       <img
         src="/static/images/login_logo.png"
         alt="PixiePinks Logo"
-        class="w-72 h-auto object-contain drop-shadow-lg"
+        class="w-52 h-auto object-contain drop-shadow-lg"
       >
     </div>
 


### PR DESCRIPTION
### Motivation
- Reduce the login page logo width by ~30% while keeping aspect ratio and responsive behavior by adjusting the Tailwind width utility.

### Description
- Updated `templates/login.html` to replace `class="w-72 h-auto object-contain drop-shadow-lg"` with `class="w-52 h-auto object-contain drop-shadow-lg"`.

### Testing
- Ran an automated one-shot replacement (`python - <<'PY' ...`) to update the template and verified the change with `git diff -- templates/login.html`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06af54a9388325b41ce64added26b2)