### PR TITLE
Add CRM module for WhatsApp lead management

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,12 +6,12 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from starlette.middleware.sessions import SessionMiddleware
-from sqlalchemy import func, inspect, text
+from sqlalchemy import func, inspect, text, or_
 from sqlalchemy.orm import Session
 
 from settings import settings
 from database import SessionLocal, engine
-from models import Account, JournalEntry, JournalLine, User, Base, Customer, Supplier, Item
+from models import Account, JournalEntry, JournalLine, User, Base, Customer, Supplier, Item, Lead, LeadNote, LeadTask
 from seed import init_db
 from utils_auth import hash_password, verify_password
 
@@ -38,6 +38,40 @@ def get_db():
 
 # ---------------------- Helpers ----------------------
 LOGIN_PATH = "/login"
+
+
+LEAD_STATUSES = [
+    "NEW",
+    "REPLIED",
+    "INTERESTED",
+    "FOLLOW_UP",
+    "NEGOTIATING",
+    "PAYMENT_PENDING",
+    "ORDER_CONFIRMED",
+    "DELIVERED",
+    "LOST",
+]
+
+
+def _generate_lead_no(db: Session, dt: date | None = None) -> str:
+    dt = dt or date.today()
+    year = dt.year
+    prefix = f"LD-{year}-"
+    latest = (
+        db.query(Lead)
+        .filter(Lead.lead_no.like(f"{prefix}%"))
+        .order_by(Lead.id.desc())
+        .first()
+    )
+    if latest and latest.lead_no:
+        try:
+            seq = int(latest.lead_no.split("-")[-1]) + 1
+        except ValueError:
+            seq = 1
+    else:
+        seq = 1
+    return f"{prefix}{seq:05d}"
+
 
 def _is_safe_next(next_url: str) -> bool:
     try:
@@ -274,6 +308,124 @@ def delete_item(item_id: int, db: Session = Depends(get_db), user: User = Depend
     db.delete(i)
     db.commit()
     return RedirectResponse("/items", status_code=303)
+
+
+# ---------------------- CRM ----------------------
+@app.get("/crm", response_class=HTMLResponse)
+def crm_dashboard(request: Request, db: Session = Depends(get_db), user: User = Depends(require_user)):
+    today = date.today()
+    total_leads = db.query(func.count(Lead.id)).scalar() or 0
+    new_leads = db.query(func.count(Lead.id)).filter(Lead.status == "NEW").scalar() or 0
+    followups_today = db.query(func.count(Lead.id)).filter(Lead.next_followup == today).scalar() or 0
+    completed_sales = db.query(func.count(Lead.id)).filter(Lead.status == "DELIVERED").scalar() or 0
+    lost_leads = db.query(func.count(Lead.id)).filter(Lead.status == "LOST").scalar() or 0
+
+    pending_followups = (
+        db.query(Lead)
+        .filter(Lead.next_followup.is_not(None), Lead.next_followup <= today, Lead.status.notin_(["DELIVERED", "LOST"]))
+        .order_by(Lead.next_followup.asc(), Lead.created_at.desc())
+        .all()
+    )
+
+    recent_leads = db.query(Lead).order_by(Lead.created_at.desc(), Lead.id.desc()).limit(10).all()
+
+    return templates.TemplateResponse("crm_dashboard.html", {
+        "request": request,
+        "total_leads": total_leads,
+        "new_leads": new_leads,
+        "followups_today": followups_today,
+        "completed_sales": completed_sales,
+        "lost_leads": lost_leads,
+        "recent_leads": recent_leads,
+        "pending_followups": pending_followups,
+    })
+
+
+@app.get("/crm/leads", response_class=HTMLResponse)
+def crm_leads(request: Request, q: str = "", db: Session = Depends(get_db), user: User = Depends(require_user)):
+    query = db.query(Lead)
+    q = q.strip()
+    if q:
+        like = f"%{q}%"
+        query = query.filter(or_(Lead.customer_name.ilike(like), Lead.mobile.ilike(like), Lead.city.ilike(like)))
+    leads = query.order_by(Lead.created_at.desc(), Lead.id.desc()).all()
+    return templates.TemplateResponse("crm_leads.html", {"request": request, "leads": leads, "statuses": LEAD_STATUSES, "q": q})
+
+
+@app.post("/crm/leads")
+def crm_create_lead(
+    customer_name: str = Form(...),
+    mobile: str = Form(...),
+    city: str = Form(""),
+    product_interest: str = Form(""),
+    status: str = Form("NEW"),
+    assigned_to: str = Form(""),
+    notes: str = Form(""),
+    next_followup: str = Form(""),
+    db: Session = Depends(get_db),
+    user: User = Depends(require_user),
+):
+    lead = Lead(
+        lead_no=_generate_lead_no(db),
+        customer_name=customer_name.strip(),
+        mobile=mobile.strip(),
+        city=city.strip(),
+        product_interest=product_interest.strip(),
+        status=status if status in LEAD_STATUSES else "NEW",
+        assigned_to=assigned_to.strip(),
+        notes=notes.strip(),
+        next_followup=datetime.strptime(next_followup, "%Y-%m-%d").date() if next_followup else None,
+    )
+    db.add(lead)
+    db.commit()
+    return RedirectResponse("/crm/leads", status_code=303)
+
+
+@app.get("/crm/leads/{lead_id}", response_class=HTMLResponse)
+def crm_lead_view(lead_id: int, request: Request, db: Session = Depends(get_db), user: User = Depends(require_user)):
+    lead = db.get(Lead, lead_id)
+    if not lead:
+        raise HTTPException(status_code=404, detail="Lead not found")
+
+    notes = db.query(LeadNote).filter(LeadNote.lead_id == lead_id).order_by(LeadNote.created_at.desc()).all()
+    tasks = db.query(LeadTask).filter(LeadTask.lead_id == lead_id).order_by(LeadTask.task_date.desc(), LeadTask.id.desc()).all()
+
+    return templates.TemplateResponse("crm_lead_view.html", {
+        "request": request, "lead": lead, "notes": notes, "tasks": tasks, "statuses": LEAD_STATUSES
+    })
+
+
+@app.post("/crm/leads/{lead_id}/note")
+def crm_add_note(lead_id: int, note: str = Form(...), db: Session = Depends(get_db), user: User = Depends(require_user)):
+    lead = db.get(Lead, lead_id)
+    if not lead:
+        raise HTTPException(status_code=404, detail="Lead not found")
+    db.add(LeadNote(lead_id=lead_id, note=note.strip()))
+    db.commit()
+    return RedirectResponse(f"/crm/leads/{lead_id}", status_code=303)
+
+
+@app.post("/crm/leads/{lead_id}/followup")
+def crm_add_followup(
+    lead_id: int,
+    task_date: str = Form(...),
+    status: str = Form("PENDING"),
+    note: str = Form(""),
+    db: Session = Depends(get_db),
+    user: User = Depends(require_user),
+):
+    lead = db.get(Lead, lead_id)
+    if not lead:
+        raise HTTPException(status_code=404, detail="Lead not found")
+
+    parsed_date = datetime.strptime(task_date, "%Y-%m-%d").date()
+    task = LeadTask(lead_id=lead_id, task_date=parsed_date, status=status.strip().upper(), note=note.strip())
+    lead.next_followup = parsed_date
+    if status in LEAD_STATUSES:
+        lead.status = status
+    db.add(task)
+    db.commit()
+    return RedirectResponse(f"/crm/leads/{lead_id}", status_code=303)
 
 
 # ---------------------- Entries ----------------------

--- a/models.py
+++ b/models.py
@@ -84,3 +84,43 @@ class User(Base):
     id = Column(Integer, primary_key=True)
     username = Column(String(100), unique=True, nullable=False, index=True)
     password_hash = Column(String(255), nullable=False)
+
+
+# ----------------------
+# CRM
+# ----------------------
+class Lead(Base):
+    __tablename__ = "leads"
+
+    id = Column(Integer, primary_key=True, index=True)
+    lead_no = Column(String, unique=True, index=True)
+    customer_name = Column(String, nullable=False)
+    mobile = Column(String, nullable=False)
+    city = Column(String)
+    source = Column(String, default="WhatsApp")
+    status = Column(String, default="NEW")
+    assigned_to = Column(String)
+    product_interest = Column(String)
+    notes = Column(Text)
+    next_followup = Column(Date)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class LeadNote(Base):
+    __tablename__ = "lead_notes"
+
+    id = Column(Integer, primary_key=True)
+    lead_id = Column(Integer, ForeignKey("leads.id"))
+    note = Column(Text)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class LeadTask(Base):
+    __tablename__ = "lead_tasks"
+
+    id = Column(Integer, primary_key=True)
+    lead_id = Column(Integer, ForeignKey("leads.id"))
+    task_date = Column(Date)
+    status = Column(String, default="PENDING")
+    note = Column(Text)
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,13 +11,14 @@
   {% if request.url.path != '/login' %}
   <nav class="bg-white shadow mb-6">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex gap-6 py-4">
+      <div class="flex gap-6 py-4 overflow-x-auto whitespace-nowrap">
         <a href="/dashboard">Dashboard</a>
-        <a href="/entries">Journal</a>
-        <a href="/accounts">Chart of Accounts</a>
+        <a href="/crm">CRM</a>
         <a href="/customers">Customers</a>
         <a href="/suppliers">Suppliers</a>
         <a href="/items">Items</a>
+        <a href="/entries">Journal</a>
+        <a href="/accounts">Chart of Accounts</a>
         <a href="/reports/trial-balance">Trial Balance</a>
         <a href="/reports/income-statement">Income Statement</a>
         <a href="/reports/balance-sheet">Balance Sheet</a>

--- a/templates/crm_dashboard.html
+++ b/templates/crm_dashboard.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="space-y-6">
+  <div class="flex items-center justify-between">
+    <h1 class="text-2xl font-bold text-gray-900">CRM Dashboard</h1>
+    <a href="/crm/leads" class="bg-emerald-600 text-white px-4 py-2 rounded-lg">Manage Leads</a>
+  </div>
+
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
+    <div class="bg-white rounded-xl shadow p-4"><p class="text-sm text-gray-500">Total Leads</p><p class="text-2xl font-bold">{{ total_leads }}</p></div>
+    <div class="bg-white rounded-xl shadow p-4"><p class="text-sm text-gray-500">New Leads</p><p class="text-2xl font-bold text-emerald-600">{{ new_leads }}</p></div>
+    <div class="bg-white rounded-xl shadow p-4"><p class="text-sm text-gray-500">Follow-ups Today</p><p class="text-2xl font-bold">{{ followups_today }}</p></div>
+    <div class="bg-white rounded-xl shadow p-4"><p class="text-sm text-gray-500">Completed Sales</p><p class="text-2xl font-bold text-blue-600">{{ completed_sales }}</p></div>
+    <div class="bg-white rounded-xl shadow p-4"><p class="text-sm text-gray-500">Lost Leads</p><p class="text-2xl font-bold text-rose-600">{{ lost_leads }}</p></div>
+  </div>
+
+  <div class="bg-rose-50 border border-rose-200 rounded-xl p-4">
+    <h2 class="font-semibold text-rose-700">Today's Pending Follow-ups</h2>
+    {% if pending_followups %}
+      <ul class="mt-3 space-y-2">
+        {% for lead in pending_followups %}
+          <li><a class="text-rose-700 underline" href="/crm/leads/{{ lead.id }}">{{ lead.lead_no }} - {{ lead.customer_name }} ({{ lead.next_followup }})</a></li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="text-sm text-rose-600 mt-2">No pending follow-ups.</p>
+    {% endif %}
+  </div>
+
+  <div class="bg-white rounded-xl shadow p-4">
+    <h2 class="font-semibold mb-3">Recent Leads</h2>
+    <div class="overflow-x-auto">
+      <table class="min-w-full text-sm">
+        <thead><tr class="text-left border-b"><th class="py-2">Lead No</th><th>Customer</th><th>Mobile</th><th>Status</th><th>Next Follow-up</th></tr></thead>
+        <tbody>
+        {% for lead in recent_leads %}
+          <tr class="border-b"><td class="py-2"><a class="text-emerald-700 underline" href="/crm/leads/{{ lead.id }}">{{ lead.lead_no }}</a></td><td>{{ lead.customer_name }}</td><td>{{ lead.mobile }}</td><td>{{ lead.status }}</td><td>{{ lead.next_followup or '-' }}</td></tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/crm_lead_view.html
+++ b/templates/crm_lead_view.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="space-y-6">
+  <a href="/crm/leads" class="text-emerald-700 underline">← Back to Leads</a>
+  <div class="bg-white rounded-xl shadow p-4">
+    <h1 class="text-2xl font-bold">{{ lead.customer_name }} <span class="text-sm text-gray-500">({{ lead.lead_no }})</span></h1>
+    <p class="text-sm mt-2">Mobile: {{ lead.mobile }} | City: {{ lead.city or '-' }} | Product: {{ lead.product_interest or '-' }}</p>
+    <p class="text-sm">Status: <span class="font-semibold">{{ lead.status }}</span> | Assigned: {{ lead.assigned_to or '-' }} | Next Follow-up: {{ lead.next_followup or '-' }}</p>
+    <p class="text-sm mt-2">Notes: {{ lead.notes or '-' }}</p>
+  </div>
+
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+    <div class="bg-white rounded-xl shadow p-4">
+      <h2 class="font-semibold mb-3">Notes History</h2>
+      <form method="post" action="/crm/leads/{{ lead.id }}/note" class="space-y-2 mb-3">
+        <textarea name="note" required class="w-full border rounded-lg px-3 py-2" placeholder="Add note"></textarea>
+        <button class="bg-emerald-600 text-white rounded-lg px-3 py-2">Add Note</button>
+      </form>
+      {% for n in notes %}<div class="border rounded-lg p-2 mb-2 text-sm"><p>{{ n.note }}</p><p class="text-gray-500">{{ n.created_at }}</p></div>{% endfor %}
+    </div>
+
+    <div class="bg-white rounded-xl shadow p-4">
+      <h2 class="font-semibold mb-3">Follow-up History</h2>
+      <form method="post" action="/crm/leads/{{ lead.id }}/followup" class="grid grid-cols-1 gap-2 mb-3">
+        <input type="date" name="task_date" required class="border rounded-lg px-3 py-2">
+        <select name="status" class="border rounded-lg px-3 py-2"><option value="PENDING">PENDING</option>{% for s in statuses %}<option value="{{ s }}">{{ s }}</option>{% endfor %}</select>
+        <input name="note" placeholder="Follow-up note" class="border rounded-lg px-3 py-2">
+        <button class="bg-emerald-600 text-white rounded-lg px-3 py-2">Add Follow-up</button>
+      </form>
+      {% for t in tasks %}<div class="border rounded-lg p-2 mb-2 text-sm"><p>{{ t.task_date }} - {{ t.status }}</p><p>{{ t.note or '-' }}</p></div>{% endfor %}
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/crm_leads.html
+++ b/templates/crm_leads.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="space-y-6">
+  <h1 class="text-2xl font-bold">CRM Leads</h1>
+  <form method="get" class="bg-white rounded-xl shadow p-4 grid grid-cols-1 md:grid-cols-4 gap-3">
+    <input name="q" value="{{ q }}" placeholder="Search name, mobile, city" class="border rounded-lg px-3 py-2 md:col-span-3">
+    <button class="bg-emerald-600 text-white rounded-lg px-3 py-2">Search</button>
+  </form>
+
+  <form method="post" action="/crm/leads" class="bg-white rounded-xl shadow p-4 grid grid-cols-1 md:grid-cols-2 gap-3">
+    <input name="customer_name" required placeholder="Customer Name" class="border rounded-lg px-3 py-2">
+    <input name="mobile" required placeholder="Mobile" class="border rounded-lg px-3 py-2">
+    <input name="city" placeholder="City" class="border rounded-lg px-3 py-2">
+    <input name="product_interest" placeholder="Product Interest" class="border rounded-lg px-3 py-2">
+    <select name="status" class="border rounded-lg px-3 py-2">{% for s in statuses %}<option value="{{ s }}">{{ s }}</option>{% endfor %}</select>
+    <input name="assigned_to" placeholder="Assigned To" class="border rounded-lg px-3 py-2">
+    <input type="date" name="next_followup" class="border rounded-lg px-3 py-2">
+    <input name="notes" placeholder="Notes" class="border rounded-lg px-3 py-2 md:col-span-2">
+    <button class="bg-emerald-600 text-white rounded-lg px-3 py-2 md:col-span-2">Add Lead</button>
+  </form>
+
+  <div class="bg-white rounded-xl shadow p-4 overflow-x-auto">
+    <table class="min-w-full text-sm">
+      <thead><tr class="border-b text-left"><th>Lead No</th><th>Date</th><th>Customer</th><th>Mobile</th><th>City</th><th>Product</th><th>Status</th><th>Assigned To</th><th>Next Follow-up</th><th>Actions</th></tr></thead>
+      <tbody>
+      {% for lead in leads %}
+      <tr class="border-b"><td>{{ lead.lead_no }}</td><td>{{ lead.created_at.date() if lead.created_at else '-' }}</td><td>{{ lead.customer_name }}</td><td>{{ lead.mobile }}</td><td>{{ lead.city or '-' }}</td><td>{{ lead.product_interest or '-' }}</td><td>{{ lead.status }}</td><td>{{ lead.assigned_to or '-' }}</td><td>{{ lead.next_followup or '-' }}</td><td><a href="/crm/leads/{{ lead.id }}" class="text-emerald-700 underline">View</a></td></tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
### Motivation
- Add a lightweight CRM inside the existing PixiePinks Ledger to manage WhatsApp leads, notes and follow-ups without touching existing accounting or authentication flows. 
- Provide a simple pipeline and follow-up alerting so sales staff can manually track and act on leads. 
- Integrate the CRM UI into the existing layout so the feature is accessible via the main navbar and reuses session authentication. 

### Description
- Added new ORM models `Lead`, `LeadNote`, and `LeadTask` in `models.py` to persist leads, note history and follow-up tasks with `Text`, `Date`, and `DateTime` fields and `datetime.utcnow` defaults. 
- Implemented CRM backend in `main.py` including `LEAD_STATUSES`, auto lead number generation `_generate_lead_no` (format `LD-YYYY-00001`), and protected routes `GET /crm`, `GET /crm/leads`, `POST /crm/leads`, `GET /crm/leads/{lead_id}`, `POST /crm/leads/{lead_id}/note`, and `POST /crm/leads/{lead_id}/followup`. 
- Implemented search by customer/mobile/city (via `q` param using `or_`), follow-up alerting (leads with `next_followup <= today` and status not in `DELIVERED`/`LOST`), newest-first lead listing, and updates to `Base.metadata.create_all` behavior to include new tables at startup. 
- Added responsive Tailwind templates `templates/crm_dashboard.html`, `templates/crm_leads.html`, and `templates/crm_lead_view.html`, and exposed `CRM` in `templates/base.html` navbar while preserving existing navigation and authentication. 

### Testing
- Successfully type-checked/compiled the modified modules with `python -m py_compile main.py models.py` (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06b2f5e8e8832592289816b031e511)