### PR TITLE
Add CRM assignee dropdown with inline assignee creation

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 
 from settings import settings
 from database import SessionLocal, engine
-from models import Account, JournalEntry, JournalLine, User, Base, Customer, Supplier, Item, Lead, LeadNote, LeadTask
+from models import Account, JournalEntry, JournalLine, User, Base, Customer, Supplier, Item, Lead, LeadNote, LeadTask, CRMUser
 from seed import init_db
 from utils_auth import hash_password, verify_password
 
@@ -349,7 +349,8 @@ def crm_leads(request: Request, q: str = "", db: Session = Depends(get_db), user
         like = f"%{q}%"
         query = query.filter(or_(Lead.customer_name.ilike(like), Lead.mobile.ilike(like), Lead.city.ilike(like)))
     leads = query.order_by(Lead.created_at.desc(), Lead.id.desc()).all()
-    return templates.TemplateResponse("crm_leads.html", {"request": request, "leads": leads, "statuses": LEAD_STATUSES, "q": q})
+    crm_users = db.query(CRMUser).order_by(CRMUser.name).all()
+    return templates.TemplateResponse("crm_leads.html", {"request": request, "leads": leads, "statuses": LEAD_STATUSES, "q": q, "crm_users": crm_users})
 
 
 @app.post("/crm/leads")
@@ -360,11 +361,23 @@ def crm_create_lead(
     product_interest: str = Form(""),
     status: str = Form("NEW"),
     assigned_to: str = Form(""),
+    new_assignee: str = Form(""),
     notes: str = Form(""),
     next_followup: str = Form(""),
     db: Session = Depends(get_db),
     user: User = Depends(require_user),
 ):
+    selected_assigned_to = assigned_to.strip()
+    new_assignee_name = new_assignee.strip()
+
+    if new_assignee_name:
+        existing_user = db.query(CRMUser).filter(func.lower(CRMUser.name) == new_assignee_name.lower()).first()
+        if not existing_user:
+            db.add(CRMUser(name=new_assignee_name))
+        selected_assigned_to = new_assignee_name
+    elif selected_assigned_to == "__new__":
+        selected_assigned_to = ""
+
     lead = Lead(
         lead_no=_generate_lead_no(db),
         customer_name=customer_name.strip(),
@@ -372,7 +385,7 @@ def crm_create_lead(
         city=city.strip(),
         product_interest=product_interest.strip(),
         status=status if status in LEAD_STATUSES else "NEW",
-        assigned_to=assigned_to.strip(),
+        assigned_to=selected_assigned_to,
         notes=notes.strip(),
         next_followup=datetime.strptime(next_followup, "%Y-%m-%d").date() if next_followup else None,
     )

--- a/models.py
+++ b/models.py
@@ -89,6 +89,15 @@ class User(Base):
 # ----------------------
 # CRM
 # ----------------------
+
+
+class CRMUser(Base):
+    __tablename__ = "crm_users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
 class Lead(Base):
     __tablename__ = "leads"
 

--- a/templates/crm_leads.html
+++ b/templates/crm_leads.html
@@ -13,7 +13,17 @@
     <input name="city" placeholder="City" class="border rounded-lg px-3 py-2">
     <input name="product_interest" placeholder="Product Interest" class="border rounded-lg px-3 py-2">
     <select name="status" class="border rounded-lg px-3 py-2">{% for s in statuses %}<option value="{{ s }}">{{ s }}</option>{% endfor %}</select>
-    <input name="assigned_to" placeholder="Assigned To" class="border rounded-lg px-3 py-2">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+      <select name="assigned_to" id="assigned_to_select" class="border rounded-xl p-3">
+        <option value="">-- Select Assignee --</option>
+        {% for user in crm_users %}
+        <option value="{{ user.name }}">{{ user.name }}</option>
+        {% endfor %}
+        <option value="__new__">+ Add New Assignee</option>
+      </select>
+
+      <input type="text" name="new_assignee" id="new_assignee_input" placeholder="Enter new assignee name" class="border rounded-xl p-3 hidden">
+    </div>
     <input type="date" name="next_followup" class="border rounded-lg px-3 py-2">
     <input name="notes" placeholder="Notes" class="border rounded-lg px-3 py-2 md:col-span-2">
     <button class="bg-emerald-600 text-white rounded-lg px-3 py-2 md:col-span-2">Add Lead</button>
@@ -30,4 +40,22 @@
     </table>
   </div>
 </div>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+    const select = document.getElementById("assigned_to_select");
+    const input = document.getElementById("new_assignee_input");
+
+    if (!select || !input) return;
+
+    select.addEventListener("change", function () {
+        if (this.value === "__new__") {
+            input.classList.remove("hidden");
+            input.required = true;
+        } else {
+            input.classList.add("hidden");
+            input.required = false;
+        }
+    });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Replace the free-text `assigned_to` field on the CRM leads form with a reusable, selectable assignee list for consistency and discoverability.
- Allow creating a new assignee from the same form so users can add people without leaving the lead creation flow.
- Persist assignees so they can be re-used across leads and presented in a sorted dropdown.

### Description
- Add a new SQLAlchemy model `CRMUser` (backed by `crm_users`) with `id`, unique `name`, and `created_at` to persist assignees.
- Update the `/crm/leads` GET route to query `CRMUser` ordered by `name` and include `crm_users` in the template context.
- Update the `/crm/leads` POST route to accept `new_assignee`, perform a case-insensitive existence check, create a `CRMUser` when needed, and set `Lead.assigned_to` from either the selected assignee or the newly created one.
- Replace the old `assigned_to` text input in `templates/crm_leads.html` with a dropdown that includes existing assignees and a `+ Add New Assignee` option, add an inline `new_assignee` text input, and add client-side JS to toggle visibility/required state.

### Testing
- Ran `python -m py_compile main.py models.py` and the compilation check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06b6f439788325a46564473e5f186a)